### PR TITLE
Added transaction support to update and delete operations

### DIFF
--- a/Criteria/IDCriteria.js
+++ b/Criteria/IDCriteria.js
@@ -13,9 +13,13 @@ class IDCriteria extends CriteriaBase {
    * Constructor of the ID filter Criteria
    *
    * @param {string} id The ID on which we filter.
+   * @param {Object|null} [transaction=null] The transaction object if you want
+   *                                         the data to be used in a transaction.
    */
-  constructor(id) {
+  constructor(id, transaction = null) {
     super();
+
+    this.transaction = transaction;
 
     this._where = {
       id

--- a/RepositoryBase.js
+++ b/RepositoryBase.js
@@ -263,24 +263,32 @@ class RepositoryBase extends PObject {
    *
    * @param {string} id The ID of the element we want to update.
    * @param {Array} data The data we need to store.
+   * @param {Object|null} [transaction=null] The transaction we want to use.
    * @throws RepositoryException
    *
    * @return {Object}
    */
-  update(id, data) {
-    return this.updateByCriteria(new IDCriteria(id), data);
+  update(id, data, transaction = null) {
+    const criteria = new IDCriteria(id);
+    criteria.transaction = transaction;
+
+    return this.updateByCriteria(criteria, data);
   }
 
   /**
    * Deletes the element with the given ID.
    *
    * @param {string} id The ID of the element we want to delete.
+   * @param {Object|null} [transaction=null] The transaction we want to use.
    * @throws RepositoryException
    *
    * @return {Object}
    */
-  delete(id) {
-    return this.deleteByCriteria(new IDCriteria(id));
+  delete(id, transaction = null) {
+    const criteria = new IDCriteria(id);
+    criteria.transaction = transaction;
+
+    return this.deleteByCriteria(criteria);
   }
 
   /**

--- a/RepositoryBase.js
+++ b/RepositoryBase.js
@@ -269,10 +269,7 @@ class RepositoryBase extends PObject {
    * @return {Object}
    */
   update(id, data, transaction = null) {
-    const criteria = new IDCriteria(id);
-    criteria.transaction = transaction;
-
-    return this.updateByCriteria(criteria, data);
+    return this.updateByCriteria(new IDCriteria(id, transaction), data);
   }
 
   /**
@@ -285,10 +282,7 @@ class RepositoryBase extends PObject {
    * @return {Object}
    */
   delete(id, transaction = null) {
-    const criteria = new IDCriteria(id);
-    criteria.transaction = transaction;
-
-    return this.deleteByCriteria(criteria);
+    return this.deleteByCriteria(new IDCriteria(id, transaction));
   }
 
   /**


### PR DESCRIPTION
**Description of the Change**
Adds a new transaction parameter to both update and delete methods of RepositoryBase.
Sets the IDCriteria transaction property to this parameter.

**Alternate Designs**
Another variant would be to keep everything as it is, and use updateByCriteria or deleteByCriteria with a criteria having a transaction object. This was discarded because the update and delete would be weaker in terms of capabilities and in case the user doesn't want to use a criteria, and instead pass an id, [data], and the transaction.

**Why Should This Be In Core?**
This extends the transaction support that is already in place.

**Benefits**
Easy to use transaction based update and deletion.

**Possible Drawbacks**
One additional parameter to the existing methods

**Applicable Issues**
User wants to update or delete repository data in a transaction